### PR TITLE
feat: add get_available_servers

### DIFF
--- a/lua/mason-lspconfig/api/command.lua
+++ b/lua/mason-lspconfig/api/command.lua
@@ -123,9 +123,8 @@ _G.mason_lspconfig_completion = {
     available_server_completion = function()
         local available_servers = require("mason-lspconfig").get_available_servers()
         local language_mapping = require "mason.mappings.language"
-        local completions = _.compose(_.sort_by(_.identity), _.uniq_by(_.identity), _.concat(_.keys(language_mapping)))(
-            available_servers
-        )
+        local sort_deduped = _.compose(_.sort_by(_.identity), _.uniq_by(_.identity))
+        local completions = sort_deduped(_.concat(_.keys(language_mapping), available_servers))
         return table.concat(completions, "\n")
     end,
     installed_server_completion = function()

--- a/lua/mason-lspconfig/api/command.lua
+++ b/lua/mason-lspconfig/api/command.lua
@@ -121,26 +121,16 @@ end, {
 
 _G.mason_lspconfig_completion = {
     available_server_completion = function()
-        local registry = require "mason-registry"
-        local server_mapping = require "mason-lspconfig.mappings.server"
+        local available_servers = require("mason-lspconfig").get_available_servers()
         local language_mapping = require "mason.mappings.language"
-
-        local package_names = _.filter_map(function(pkg_name)
-            return Optional.of_nilable(server_mapping.package_to_lspconfig[pkg_name])
-        end, registry.get_all_package_names())
-        local completion =
-            _.compose(_.sort_by(_.identity), _.uniq_by(_.identity), _.concat(_.keys(language_mapping)))(package_names)
-        return table.concat(completion, "\n")
+        local completions = _.compose(_.sort_by(_.identity), _.uniq_by(_.identity), _.concat(_.keys(language_mapping)))(
+            available_servers
+        )
+        return table.concat(completions, "\n")
     end,
     installed_server_completion = function()
-        local registry = require "mason-registry"
-        local server_mapping = require "mason-lspconfig.mappings.server"
-
-        local server_names = _.filter_map(function(pkg_name)
-            return Optional.of_nilable(server_mapping.package_to_lspconfig[pkg_name])
-        end, registry.get_installed_package_names())
-        table.sort(server_names)
-        return table.concat(server_names, "\n")
+        local installed_servers = require("mason-lspconfig").get_installed_servers()
+        return table.concat(installed_servers, "\n")
     end,
 }
 

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -78,4 +78,16 @@ function M.get_installed_servers()
     end, registry.get_installed_package_names())
 end
 
+---Get a list of available servers in mason-registry
+---@return string[]
+function M.get_available_servers()
+    local registry = require "mason-registry"
+    local server_mapping = require "mason-lspconfig.mappings.server"
+    local Optional = require "mason-core.optional"
+    local server_names = _.filter_map(function(pkg_name)
+        return Optional.of_nilable(server_mapping.package_to_lspconfig[pkg_name])
+    end, registry.get_all_package_names())
+    return server_names
+end
+
 return M


### PR DESCRIPTION
## Description

- extract the logic from the `available_server_completion` into a dedicated function that is re-usable

	```lua
	require("mason-lspconfig").get_available_servers()
	```
	
- use `get_installed_servers` to remove duplicate logic in `installed_server_completion`


