### PR TITLE
feat: get_available_servers now accepts a filter

### DIFF
--- a/doc/mason-lspconfig.txt
+++ b/doc/mason-lspconfig.txt
@@ -234,7 +234,7 @@ get_installed_servers()
         |mason-registry.get_installed_package_names()|
 
                                      *mason-lspconfig.get_available_servers()*
-get_available_servers()
+get_available_servers({filter})
     Returns the available (both installed & uninstalled) LSP servers.
 
     Note: ~
@@ -243,6 +243,13 @@ get_available_servers()
         "lua-language-server". This is useful if you want to loop through the
         table and use its values to directly interact with lspconfig (for
         example setting up all installed servers).
+
+    Parameters: ~
+        {filter}  (table|nil) A table with key-value pairs used to
+                  filter the list of server names. The available keys
+                  are:
+                  • filetype (string): Only return servers with matching
+                  fileyupe
 
     Returns: ~
         string[]

--- a/doc/mason-lspconfig.txt
+++ b/doc/mason-lspconfig.txt
@@ -246,10 +246,9 @@ get_available_servers({filter})
 
     Parameters: ~
         {filter}  (table|nil) A table with key-value pairs used to
-                  filter the list of server names. The available keys
-                  are:
-                  • filetype (string): Only return servers with matching
-                  fileyupe
+                  filter the list of server names. The available keys are:
+                  - filetype (string | string[]): Only return servers with
+                    matching filetype
 
     Returns: ~
         string[]

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -79,15 +79,25 @@ function M.get_installed_servers()
 end
 
 ---Get a list of available servers in mason-registry
+---@param filter {filetype: string}? (optional) used to filter the list of server names
+--    The available keys are
+--    - filetype (string): Only return servers with matching fileyupe
 ---@return string[]
-function M.get_available_servers()
+function M.get_available_servers(filter)
     local registry = require "mason-registry"
     local server_mapping = require "mason-lspconfig.mappings.server"
     local Optional = require "mason-core.optional"
-    local server_names = _.filter_map(function(pkg_name)
-        return Optional.of_nilable(server_mapping.package_to_lspconfig[pkg_name])
-    end, registry.get_all_package_names())
-    return server_names
+    local filetype_mapping = require "mason-lspconfig.mappings.filetype"
+    filter = filter or {}
+    return Optional.of_nilable(filetype_mapping[filter.filetype])
+        :map(function(server_names)
+            return server_names
+        end)
+        :or_else_get(function()
+            return _.filter_map(function(pkg_name)
+                return Optional.of_nilable(server_mapping.package_to_lspconfig[pkg_name])
+            end, registry.get_all_package_names())
+        end)
 end
 
 return M

--- a/tests/mason-lspconfig/api/api_spec.lua
+++ b/tests/mason-lspconfig/api/api_spec.lua
@@ -29,4 +29,13 @@ describe("mason-lspconfig API", function()
             )
         )
     end)
+
+    it("should return no servers if filetype predicate has no matches", function()
+        assert.same(
+            {},
+            mason_lspconfig.get_available_servers {
+                filetype = { "thisfiletypesimplydoesntexist" },
+            }
+        )
+    end)
 end)

--- a/tests/mason-lspconfig/api/api_spec.lua
+++ b/tests/mason-lspconfig/api/api_spec.lua
@@ -3,7 +3,9 @@ local _ = require "mason-core.functional"
 
 describe("mason-lspconfig API", function()
     it("should return all available servers", function()
-        assert.equals(116, #mason_lspconfig.get_available_servers())
+        local server_mappings = require "mason-lspconfig.mappings.server"
+        local available_servers = mason_lspconfig.get_available_servers()
+        assert.equal(#vim.tbl_keys(server_mappings.package_to_lspconfig), #available_servers)
     end)
 
     it("should return all available servers for given filetype", function()

--- a/tests/mason-lspconfig/api/api_spec.lua
+++ b/tests/mason-lspconfig/api/api_spec.lua
@@ -1,0 +1,32 @@
+local mason_lspconfig = require "mason-lspconfig"
+local _ = require "mason-core.functional"
+
+describe("mason-lspconfig API", function()
+    it("should return all available servers", function()
+        assert.equals(116, #mason_lspconfig.get_available_servers())
+    end)
+
+    it("should return all available servers for given filetype", function()
+        assert.same(
+            { "terraformls", "tflint" },
+            _.sort_by(
+                _.identity,
+                mason_lspconfig.get_available_servers {
+                    filetype = "terraform",
+                }
+            )
+        )
+    end)
+
+    it("should return all available servers for given filetypes", function()
+        assert.same(
+            { "lemminx", "taplo" },
+            _.sort_by(
+                _.identity,
+                mason_lspconfig.get_available_servers {
+                    filetype = { "xml", "xsd", "xsl", "toml" },
+                }
+            )
+        )
+    end)
+end)


### PR DESCRIPTION
## Description

Allow `get_available_servers` to accept a query filter

The available keys are
- filetype (string): Only return servers with matching fileyupe

related: https://github.com/williamboman/mason.nvim/issues/86

### How has this been tested?

```lua
local all_servers = get_available_servers()
local js_servers = get_available_servers({ ft = "javascript" })
```

### TODOs
- [x] this current returns the full list of servers if the filetype query fails (regardless if the filetype is actually valid from the start)
- [ ] this should probably be used in `parse_packages_from_heuristics`
- [ ] we could probably use an `is_valid_server()`, see the test-case in https://github.com/williamboman/mason-lspconfig.nvim/commit/358f6279b5b1ba2378c8be2d00860403223e91be