### PR TITLE
fix(julials)!: change cmd to use new Mason-linked executable

### DIFF
--- a/lua/mason-lspconfig/server_configurations/julials/init.lua
+++ b/lua/mason-lspconfig/server_configurations/julials/init.lua
@@ -31,20 +31,10 @@ return function(install_dir)
             end
 
             config.cmd = {
-                "julia",
-                "--startup-file=no",
-                "--history-file=no",
-                "--depwarn=no",
-                ("--project=%s"):format(path.concat { install_dir, "scripts", "environments", "languageserver" }),
-                path.concat { install_dir, "nvim-lsp.jl" },
+                "julia-lsp",
                 vim.env.JULIA_DEPOT_PATH or "",
-                path.concat { install_dir, "symbolstorev5" },
                 env_path,
             }
         end,
-        cmd_env = {
-            JULIA_DEPOT_PATH = path.concat { install_dir, "lsdepot" },
-            JULIA_LOAD_PATH = platform.is.win and ";" or ":",
-        },
     }
 end


### PR DESCRIPTION
This is done partly for convenience reasons, but also to better guard
against breaking changes in the future (the executable itself holds more
installation-specific information now, as opposed to this function).

Fixes #30.
