### PR TITLE
feat: add drools_lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ local DEFAULT_SETTINGS = {
 | Dlang                               | `serve_d`                  |
 | Docker                              | `dockerls`                 |
 | Dot                                 | `dotls`                    |
+| Drools                              | `drools_lsp`               |
 | EFM (general purpose server)        | `efm`                      |
 | ESLint                              | `eslint`                   |
 | Elixir                              | `elixirls`                 |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -33,6 +33,7 @@ dhall-lsp                     dhall_lsp_server
 diagnostic-languageserver     diagnosticls
 dockerfile-language-server    dockerls
 dot-language-server           dotls
+drools-lsp                    drools_lsp
 efm                           efm
 elixir-ls                     elixirls
 elm-language-server           elmls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -30,6 +30,7 @@
 | [diagnosticls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#diagnosticls) | [diagnostic-languageserver](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#diagnostic-languageserver) |
 | [dockerls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dockerls) | [dockerfile-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#dockerfile-language-server) |
 | [dotls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dotls) | [dot-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#dot-language-server) |
+| [drools_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#drools_lsp) | [drools-lsp](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#drools-lsp) |
 | [efm](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#efm) | [efm](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#efm) |
 | [elixirls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#elixirls) | [elixir-ls](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#elixir-ls) |
 | [elmls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#elmls) | [elm-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#elm-language-server) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -33,6 +33,7 @@ return {
   ["django-html"] = { "tailwindcss" },
   dockerfile = { "dockerls" },
   dot = { "dotls" },
+  drools = { "drools_lsp" },
   dune = { "ocamllsp" },
   edge = { "tailwindcss" },
   edn = { "clojure_lsp" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -33,6 +33,7 @@ M.lspconfig_to_package = {
     ["diagnosticls"] = "diagnostic-languageserver",
     ["dockerls"] = "dockerfile-language-server",
     ["dotls"] = "dot-language-server",
+    ["drools_lsp"] = "drools-lsp",
     ["efm"] = "efm",
     ["elixirls"] = "elixir-ls",
     ["elmls"] = "elm-language-server",


### PR DESCRIPTION
This PR adds support for Red Hat's [Drools Rule Language](https://docs.drools.org/latest/drools-docs/docs-website/drools/language-reference/index.html#con-drl_drl-rules) (ft=`drools`, ext=`.drl`). The [drools-lsp](https://github.com/kiegroup/drools-lsp/) server config was recently merged into [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) (also written by me). The generated doc link in nvim-lspconfig is [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#drools_lsp).

The companion PR in mason.nvim is [here](https://github.com/williamboman/mason.nvim/pull/898).

_Thank you so much!_

Signed-off-by: David Ward <dward@redhat.com>