### PR TITLE
fix(drools-lsp): apply mason's package install path of the jar on behalf of the user

### DIFF
--- a/lua/mason-lspconfig/server_configurations/drools_lsp/init.lua
+++ b/lua/mason-lspconfig/server_configurations/drools_lsp/init.lua
@@ -1,0 +1,10 @@
+return function()
+    return {
+        drools = {
+            jar = require("mason-core.path").concat {
+                require("mason-registry").get_package("drools-lsp"):get_install_path(),
+                "drools-lsp-server-jar-with-dependencies.jar",
+            },
+        },
+    }
+end


### PR DESCRIPTION
fix(drools-lsp): apply mason's package install path of the jar on behalf of the user

Signed-off-by: David Ward <dward@redhat.com>