### PR TITLE
feat(solang): also include $MASON/opt/solang llvm bins

### DIFF
--- a/lua/mason-lspconfig/server_configurations/solang/init.lua
+++ b/lua/mason-lspconfig/server_configurations/solang/init.lua
@@ -3,11 +3,13 @@ local process = require "mason-core.process"
 
 ---@param install_dir string
 return function(install_dir)
+    local llvm_bins = { vim.fn.expand(path.concat { install_dir, "llvm*", "bin" }, true, true)[1] }
+    if vim.env.MASON then
+        table.insert(llvm_bins, vim.fn.expand "$MASON/opt/solang/llvm15.0/bin")
+    end
     return {
         cmd_env = {
-            PATH = process.extend_path {
-                vim.fn.expand(path.concat { install_dir, "llvm*", "bin" }, true, true)[1],
-            },
+            PATH = process.extend_path(llvm_bins),
         },
     }
 end


### PR DESCRIPTION
This will be the new location of LLVM-patched bins once https://github.com/mason-org/mason-registry/ is live.
