### PR TITLE
fix: don't auto install servers when headless

### DIFF
--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -1,5 +1,6 @@
 local _ = require "mason-core.functional"
 local log = require "mason-core.log"
+local platform = require "mason-core.platform"
 
 local M = {}
 
@@ -19,7 +20,7 @@ function M.setup(config)
         log.error("Failed to set up lspconfig integration.", err)
     end
 
-    if #settings.current.ensure_installed > 0 then
+    if not platform.is_headless and #settings.current.ensure_installed > 0 then
         require "mason-lspconfig.ensure_installed"()
     end
 

--- a/lua/mason-lspconfig/lspconfig_hook.lua
+++ b/lua/mason-lspconfig/lspconfig_hook.lua
@@ -7,6 +7,9 @@ local memoized_set = _.memoize(_.set_of)
 
 ---@param server_name string
 local function should_auto_install(server_name)
+    if platform.is_headless then
+        return false
+    end
     local settings = require "mason-lspconfig.settings"
 
     if settings.current.automatic_installation == true then


### PR DESCRIPTION
You should be able to run headless commands without mason-lspconfig starting installations in the background with
limited ability to wait until they're done.
