### PR TITLE
feat: add azure_pipelines_ls to the server mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ local DEFAULT_SETTINGS = {
 | Arduino                             | `arduino_language_server`         |
 | Assembly (GAS/NASM, GO)             | `asm_lsp`                         |
 | Astro                               | `astro`                           |
+| Azure Pipelines                     | `azure_pipelines_ls`              |
 | Bash                                | `bashls`                          |
 | Beancount                           | `beancount`                       |
 | Bicep                               | `bicep`                           |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -13,6 +13,7 @@ arduino-language-server          arduino_language_server
 asm-lsp                          asm_lsp
 astro-language-server            astro
 awk-language-server              awk_ls
+azure-pipelines-language-server  azure_pipelines_ls
 bash-language-server             bashls
 beancount-language-server        beancount
 bicep-lsp                        bicep

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -10,6 +10,7 @@
 | [asm_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#asm_lsp) | [asm-lsp](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#asm-lsp) |
 | [astro](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#astro) | [astro-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#astro-language-server) |
 | [awk_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#awk_ls) | [awk-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#awk-language-server) |
+| [azure_pipelines_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#azure_pipelines_ls) | [azure-pipelines-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#azure-pipelines-language-server) |
 | [bashls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#bashls) | [bash-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#bash-language-server) |
 | [beancount](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#beancount) | [beancount-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#beancount-language-server) |
 | [bicep](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#bicep) | [bicep-lsp](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#bicep-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -177,7 +177,7 @@ return {
   xsd = { "lemminx" },
   xsl = { "lemminx" },
   xslt = { "lemminx" },
-  yaml = { "docker_compose_language_service", "spectral", "yamlls" },
+  yaml = { "azure_pipelines_ls", "docker_compose_language_service", "spectral", "yamlls" },
   ["yaml.ansible"] = { "ansiblels" },
   ["yaml.docker-compose"] = { "yamlls" },
   yml = { "spectral" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -13,6 +13,7 @@ M.lspconfig_to_package = {
     ["asm_lsp"] = "asm-lsp",
     ["astro"] = "astro-language-server",
     ["awk_ls"] = "awk-language-server",
+    ["azure_pipelines_ls"] = "azure-pipelines-language-server",
     ["bashls"] = "bash-language-server",
     ["beancount"] = "beancount-language-server",
     ["bicep"] = "bicep-lsp",


### PR DESCRIPTION
https://github.com/neovim/nvim-lspconfig/pull/2493
https://github.com/mason-org/mason-registry/pull/1015

Should make this work:
```
mason_lspconfig.setup {
  ensure_installed = {"azure_pipelines_ls"},
}
```