### PR TITLE
feat: register package aliases

### DIFF
--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -24,9 +24,12 @@ function M.setup(config)
         require "mason-lspconfig.ensure_installed"()
     end
 
-    require("mason-registry").register_package_aliases(_.map(function(server_name)
-        return { server_name }
-    end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
+    local registry = require("mason-registry")
+    if registry.register_package_aliases then
+        require("mason-registry").register_package_aliases(_.map(function(server_name)
+            return { server_name }
+        end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
+    end
 
     require "mason-lspconfig.api.command"
 end

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -24,9 +24,9 @@ function M.setup(config)
         require "mason-lspconfig.ensure_installed"()
     end
 
-    require("mason-registry").register_aliases({
-        ['lua-language-server'] = { 'luals' }
-    })
+require("mason-registry").register_aliases(_.map(function(server_name)
+    return { server_name }
+end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
 
     require "mason-lspconfig.api.command"
 end

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -26,7 +26,7 @@ function M.setup(config)
 
     local registry = require "mason-registry"
     if registry.register_package_aliases then
-        require("mason-registry").register_package_aliases(_.map(function(server_name)
+        registry.register_package_aliases(_.map(function(server_name)
             return { server_name }
         end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
     end

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -24,7 +24,7 @@ function M.setup(config)
         require "mason-lspconfig.ensure_installed"()
     end
 
-    local registry = require("mason-registry")
+    local registry = require "mason-registry"
     if registry.register_package_aliases then
         require("mason-registry").register_package_aliases(_.map(function(server_name)
             return { server_name }

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -24,9 +24,9 @@ function M.setup(config)
         require "mason-lspconfig.ensure_installed"()
     end
 
-require("mason-registry").register_aliases(_.map(function(server_name)
-    return { server_name }
-end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
+    require("mason-registry").register_package_aliases(_.map(function(server_name)
+        return { server_name }
+    end, require("mason-lspconfig.mappings.server").package_to_lspconfig))
 
     require "mason-lspconfig.api.command"
 end

--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -24,6 +24,10 @@ function M.setup(config)
         require "mason-lspconfig.ensure_installed"()
     end
 
+    require("mason-registry").register_aliases({
+        ['lua-language-server'] = { 'luals' }
+    })
+
     require "mason-lspconfig.api.command"
 end
 

--- a/tests/mason-lspconfig/setup_spec.lua
+++ b/tests/mason-lspconfig/setup_spec.lua
@@ -226,12 +226,12 @@ describe("mason-lspconfig setup", function()
         assert.same({ name = "dummylsp", cmd = { "user-cmd" } }, config)
     end)
 
-    it("should set up package aliases", function ()
+    it("should set up package aliases", function()
         stub(registry, "register_package_aliases")
 
         require("mason-lspconfig.mappings.server").package_to_lspconfig = {
             ["rust-analyzer"] = "rust_analyzer",
-            ["typescript-language-server"] = "tsserver"
+            ["typescript-language-server"] = "tsserver",
         }
 
         mason_lspconfig.setup {}
@@ -239,7 +239,7 @@ describe("mason-lspconfig setup", function()
         assert.spy(registry.register_package_aliases).was_called(1)
         assert.spy(registry.register_package_aliases).was_called_with {
             ["rust-analyzer"] = { "rust_analyzer" },
-            ["typescript-language-server"] = { "tsserver" }
+            ["typescript-language-server"] = { "tsserver" },
         }
     end)
 end)

--- a/tests/mason-lspconfig/setup_spec.lua
+++ b/tests/mason-lspconfig/setup_spec.lua
@@ -229,10 +229,10 @@ describe("mason-lspconfig setup", function()
     it("should set up package aliases", function()
         stub(registry, "register_package_aliases")
 
-        require("mason-lspconfig.mappings.server").package_to_lspconfig = {
+        local mapping_mock = mockx.table(require "mason-lspconfig.mappings.server", "package_to_lspconfig", {
             ["rust-analyzer"] = "rust_analyzer",
             ["typescript-language-server"] = "tsserver",
-        }
+        })
 
         mason_lspconfig.setup {}
 
@@ -241,6 +241,7 @@ describe("mason-lspconfig setup", function()
             ["rust-analyzer"] = { "rust_analyzer" },
             ["typescript-language-server"] = { "tsserver" },
         }
+        mapping_mock:revert()
     end)
 end)
 

--- a/tests/mason-lspconfig/setup_spec.lua
+++ b/tests/mason-lspconfig/setup_spec.lua
@@ -225,6 +225,23 @@ describe("mason-lspconfig setup", function()
 
         assert.same({ name = "dummylsp", cmd = { "user-cmd" } }, config)
     end)
+
+    it("should set up package aliases", function ()
+        stub(registry, "register_package_aliases")
+
+        require("mason-lspconfig.mappings.server").package_to_lspconfig = {
+            ["rust-analyzer"] = "rust_analyzer",
+            ["typescript-language-server"] = "tsserver"
+        }
+
+        mason_lspconfig.setup {}
+
+        assert.spy(registry.register_package_aliases).was_called(1)
+        assert.spy(registry.register_package_aliases).was_called_with {
+            ["rust-analyzer"] = { "rust_analyzer" },
+            ["typescript-language-server"] = { "tsserver" }
+        }
+    end)
 end)
 
 describe("mason-lspconfig setup_handlers", function()

--- a/vim.yml
+++ b/vim.yml
@@ -31,6 +31,11 @@ globals:
     mockx.returns:
         args:
             - type: any
+    mockx.table:
+        args:
+            - type: table
+            - type: string
+            - type: any
 
     describe:
         args:


### PR DESCRIPTION
Implements usage of `register_aliases` added in this PR: https://github.com/williamboman/mason.nvim/pull/1146