### PR TITLE
feat: add `pylyzer` lsp to the server mapping

### DIFF
--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -96,6 +96,7 @@ M.lspconfig_to_package = {
     ["puppet"] = "puppet-editor-services",
     ["purescriptls"] = "purescript-language-server",
     ["pylsp"] = "python-lsp-server",
+    ["pylyzer"] = "pylyzer",
     ["pyre"] = "pyre",
     ["pyright"] = "pyright",
     ["quick_lint_js"] = "quick-lint-js",


### PR DESCRIPTION
From these changes
- https://github.com/neovim/nvim-lspconfig/pull/2548
- https://github.com/mason-org/mason-registry/pull/1144

This PR updates the server mapping for `pylyzer` supported