### PR TITLE
add: helm-ls autoconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@
 
 # Table of Contents
 
--   [Introduction](#introduction)
--   [Requirements](#requirements)
--   [Installation](#installation)
--   [Setup](#setup)
-    -   [Automatic server setup (advanced feature)](#automatic-server-setup-advanced-feature)
--   [Commands](#commands)
--   [Configuration](#configuration)
-    -   [Default configuration](#default-configuration)
--   [Available LSP servers](#available-lsp-servers)
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Setup](#setup)
+  - [Automatic server setup (advanced feature)](#automatic-server-setup-advanced-feature)
+- [Commands](#commands)
+- [Configuration](#configuration)
+  - [Default configuration](#default-configuration)
+- [Available LSP servers](#available-lsp-servers)
 
 # Introduction
 
@@ -31,11 +31,11 @@
 
 `mason-lspconfig.nvim` closes some gaps that exist between `mason.nvim` and `lspconfig`. Its main responsibilities are to:
 
--   register a setup hook with `lspconfig` that ensures servers installed with `mason.nvim` are set up with the necessary
+- register a setup hook with `lspconfig` that ensures servers installed with `mason.nvim` are set up with the necessary
     configuration
--   provide extra convenience APIs such as the `:LspInstall` command
--   allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
--   translate between `lspconfig` server names and `mason.nvim` package names (e.g. `lua_ls <-> lua-language-server`)
+- provide extra convenience APIs such as the `:LspInstall` command
+- allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
+- translate between `lspconfig` server names and `mason.nvim` package names (e.g. `lua_ls <-> lua-language-server`)
 
 It is recommended to use this extension if you use `mason.nvim` and `lspconfig` (it's strongly recommended for Windows
 users).
@@ -47,9 +47,9 @@ table for a complete mapping.](./doc/server-mapping.md)**
 
 > `:h mason-lspconfig-requirements`
 
--   neovim `>= 0.7.0`
--   `mason.nvim`
--   `lspconfig`
+- neovim `>= 0.7.0`
+- `mason.nvim`
+- `lspconfig`
 
 # Installation
 
@@ -107,8 +107,8 @@ Refer to `:h mason-lspconfig-automatic-server-setup` for more details.
 
 > `:h mason-lspconfig-commands`
 
--   `:LspInstall [<server>...]` - installs the provided servers
--   `:LspUninstall <server> ...` - uninstalls the provided servers
+- `:LspInstall [<server>...]` - installs the provided servers
+- `:LspUninstall <server> ...` - uninstalls the provided servers
 
 # Configuration
 
@@ -210,8 +210,8 @@ local DEFAULT_SETTINGS = {
 | HTML                                | `html`                            |
 | Haskell                             | `hls`                             |
 | Haxe                                | `haxe_language_server`            |
-| Hoon                                | `hoon_ls`                         |
 | Helm                                | `helm_ls`                         |
+| Hoon                                | `hoon_ls`                         |
 | JSON                                | `jsonls`                          |
 | Java                                | `jdtls`                           |
 | JavaScript                          | `quick_lint_js`                   |

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@
 
 # Table of Contents
 
-- [Introduction](#introduction)
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Setup](#setup)
-  - [Automatic server setup (advanced feature)](#automatic-server-setup-advanced-feature)
-- [Commands](#commands)
-- [Configuration](#configuration)
-  - [Default configuration](#default-configuration)
-- [Available LSP servers](#available-lsp-servers)
+-   [Introduction](#introduction)
+-   [Requirements](#requirements)
+-   [Installation](#installation)
+-   [Setup](#setup)
+    -   [Automatic server setup (advanced feature)](#automatic-server-setup-advanced-feature)
+-   [Commands](#commands)
+-   [Configuration](#configuration)
+    -   [Default configuration](#default-configuration)
+-   [Available LSP servers](#available-lsp-servers)
 
 # Introduction
 
@@ -31,11 +31,11 @@
 
 `mason-lspconfig.nvim` closes some gaps that exist between `mason.nvim` and `lspconfig`. Its main responsibilities are to:
 
-- register a setup hook with `lspconfig` that ensures servers installed with `mason.nvim` are set up with the necessary
+-   register a setup hook with `lspconfig` that ensures servers installed with `mason.nvim` are set up with the necessary
     configuration
-- provide extra convenience APIs such as the `:LspInstall` command
-- allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
-- translate between `lspconfig` server names and `mason.nvim` package names (e.g. `lua_ls <-> lua-language-server`)
+-   provide extra convenience APIs such as the `:LspInstall` command
+-   allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
+-   translate between `lspconfig` server names and `mason.nvim` package names (e.g. `lua_ls <-> lua-language-server`)
 
 It is recommended to use this extension if you use `mason.nvim` and `lspconfig` (it's strongly recommended for Windows
 users).
@@ -47,9 +47,9 @@ table for a complete mapping.](./doc/server-mapping.md)**
 
 > `:h mason-lspconfig-requirements`
 
-- neovim `>= 0.7.0`
-- `mason.nvim`
-- `lspconfig`
+-   neovim `>= 0.7.0`
+-   `mason.nvim`
+-   `lspconfig`
 
 # Installation
 
@@ -107,8 +107,8 @@ Refer to `:h mason-lspconfig-automatic-server-setup` for more details.
 
 > `:h mason-lspconfig-commands`
 
-- `:LspInstall [<server>...]` - installs the provided servers
-- `:LspUninstall <server> ...` - uninstalls the provided servers
+-   `:LspInstall [<server>...]` - installs the provided servers
+-   `:LspUninstall <server> ...` - uninstalls the provided servers
 
 # Configuration
 
@@ -211,6 +211,7 @@ local DEFAULT_SETTINGS = {
 | Haskell                             | `hls`                             |
 | Haxe                                | `haxe_language_server`            |
 | Hoon                                | `hoon_ls`                         |
+| Helm                                | `helm_ls`                         |
 | JSON                                | `jsonls`                          |
 | Java                                | `jdtls`                           |
 | JavaScript                          | `quick_lint_js`                   |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -60,8 +60,8 @@ grammarly-languageserver         grammarly
 graphql-language-service-cli     graphql
 groovy-language-server           groovyls
 haxe-language-server             haxe_language_server
-haskell-language-server          hls
 helm-ls                          helm_ls
+haskell-language-server          hls
 hoon-language-server             hoon_ls
 html-lsp                         html
 intelephense                     intelephense

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -61,6 +61,7 @@ graphql-language-service-cli     graphql
 groovy-language-server           groovyls
 haxe-language-server             haxe_language_server
 haskell-language-server          hls
+helm-ls                          helm_ls
 hoon-language-server             hoon_ls
 html-lsp                         html
 intelephense                     intelephense

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -57,7 +57,7 @@
 | [graphql](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#graphql) | [graphql-language-service-cli](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#graphql-language-service-cli) |
 | [groovyls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#groovyls) | [groovy-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#groovy-language-server) |
 | [haxe_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#haxe_language_server) | [haxe-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#haxe-language-server) |
-| [helm_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#helm_ls) | [helm-ls](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#helm-ls)
+| [helm_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#helm_ls) | [helm-ls](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#helm-ls) |
 | [hls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#hls) | [haskell-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#haskell-language-server) |
 | [hoon_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#hoon_ls) | [hoon-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#hoon-language-server) |
 | [html](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#html) | [html-lsp](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#html-lsp) |

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -57,6 +57,7 @@
 | [graphql](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#graphql) | [graphql-language-service-cli](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#graphql-language-service-cli) |
 | [groovyls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#groovyls) | [groovy-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#groovy-language-server) |
 | [haxe_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#haxe_language_server) | [haxe-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#haxe-language-server) |
+| [helm_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#helm_ls) | [helm-ls](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#helm-ls)
 | [hls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#hls) | [haskell-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#haskell-language-server) |
 | [hoon_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#hoon_ls) | [hoon-language-server](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#hoon-language-server) |
 | [html](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#html) | [html-lsp](https://github.com/williamboman/mason.nvim/blob/main/PACKAGES.md#html-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -67,6 +67,7 @@ return {
   haxe = { "haxe_language_server" },
   hbs = { "tailwindcss" },
   heex = { "elixirls", "tailwindcss" },
+  helm = { "helm_ls" },
   hoon = { "hoon_ls" },
   html = { "angularls", "antlersls", "emmet_ls", "html", "tailwindcss", "unocss" },
   ["html-eex"] = { "tailwindcss" },

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -67,7 +67,7 @@ return {
   haxe = { "haxe_language_server" },
   hbs = { "tailwindcss" },
   heex = { "elixirls", "tailwindcss" },
-  helm = { "helm_ls"}
+  helm = { "helm_ls" },
   hoon = { "hoon_ls" },
   html = { "angularls", "antlersls", "emmet_ls", "html", "tailwindcss", "unocss" },
   ["html-eex"] = { "tailwindcss" },

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -67,7 +67,7 @@ return {
   haxe = { "haxe_language_server" },
   hbs = { "tailwindcss" },
   heex = { "elixirls", "tailwindcss" },
-  helm = { "helm_ls" },
+  helm = { "helm_ls"}
   hoon = { "hoon_ls" },
   html = { "angularls", "antlersls", "emmet_ls", "html", "tailwindcss", "unocss" },
   ["html-eex"] = { "tailwindcss" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -60,6 +60,7 @@ M.lspconfig_to_package = {
     ["graphql"] = "graphql-language-service-cli",
     ["groovyls"] = "groovy-language-server",
     ["haxe_language_server"] = "haxe-language-server",
+    ["helm_ls"] = "helm-ls",
     ["hls"] = "haskell-language-server",
     ["hoon_ls"] = "hoon-language-server",
     ["html"] = "html-lsp",


### PR DESCRIPTION
From these change

* https://github.com/neovim/nvim-lspconfig/pull/2558
* https://github.com/mason-org/mason-registry/pull/1160

This PR updates the server mapping for `helm-ls`  supported