### PR TITLE
refactor: only notify bad setup order if it impacts functionality

### DIFF
--- a/lua/mason-lspconfig/lspconfig_hook.lua
+++ b/lua/mason-lspconfig/lspconfig_hook.lua
@@ -1,5 +1,6 @@
 local _ = require "mason-core.functional"
 local log = require "mason-core.log"
+local notify = require "mason-lspconfig.notify"
 local path = require "mason-core.path"
 local platform = require "mason-core.platform"
 
@@ -59,6 +60,15 @@ return function()
         local pkg_name = server_mapping.lspconfig_to_package[config.name]
         if not pkg_name then
             return
+        end
+
+        if require("mason").has_setup == false then
+            notify(
+                ("Server %q is being set up before mason.nvim is set up. :h mason-lspconfig-quickstart"):format(
+                    config.name
+                ),
+                vim.log.levels.WARN
+            )
         end
 
         if registry.is_installed(pkg_name) then

--- a/tests/mason-lspconfig/setup_spec.lua
+++ b/tests/mason-lspconfig/setup_spec.lua
@@ -328,4 +328,41 @@ describe("mason-lspconfig setup_handlers", function()
             )
         end)
     )
+
+    it("should notify if mason.nvim has not been set up and using ensure_installed feature", function()
+        package.loaded["mason"] = nil
+        spy.on(vim, "notify")
+
+        mason_lspconfig.setup { ensure_installed = { "dummylsp" } }
+        assert.spy(vim.notify).was_called(1)
+        assert.spy(vim.notify).was_called_with(
+            [[mason.nvim has not been set up. Make sure to set up 'mason' before 'mason-lspconfig'. :h mason-lspconfig-quickstart]],
+            vim.log.levels.WARN,
+            { title = "mason-lspconfig.nvim" }
+        )
+    end)
+
+    it("should not notify if mason.nvim has not been set up and not using ensure_installed feature", function()
+        package.loaded["mason"] = nil
+        spy.on(vim, "notify")
+
+        mason_lspconfig.setup()
+        assert.spy(vim.notify).was_called(0)
+    end)
+
+    it("should notify is server is set up before mason.nvim", function()
+        package.loaded["mason"] = nil
+        local lspconfig = require "lspconfig"
+        spy.on(vim, "notify")
+
+        mason_lspconfig.setup()
+        lspconfig.dummylsp.setup {}
+
+        assert.spy(vim.notify).was_called(1)
+        assert.spy(vim.notify).was_called_with(
+            [[Server "dummylsp" is being set up before mason.nvim is set up. :h mason-lspconfig-quickstart]],
+            vim.log.levels.WARN,
+            { title = "mason-lspconfig.nvim" }
+        )
+    end)
 end)


### PR DESCRIPTION
Many users probably set these up in the wrong order but experience no impact on functionality. These may think the notification is a breaking change when it's not, so the trade-off here is to only notify when we know it impacts functionality.