### PR TITLE
azure_pipelines_ls: Specify cmd

### DIFF
--- a/lua/mason-lspconfig/server_configurations/azure_pipelines_ls/init.lua
+++ b/lua/mason-lspconfig/server_configurations/azure_pipelines_ls/init.lua
@@ -1,0 +1,5 @@
+return function()
+    return {
+        cmd = { "azure-pipelines-language-server", "--stdio" },
+    }
+end


### PR DESCRIPTION
cmd for azure_pipelines_ls is empty in nvim-lspconfig, thus setting it to a working command. This approach follows similar fix for visualforce_ls