### PR TITLE
Add mappings and alias for the sonar lint server

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ local DEFAULT_SETTINGS = {
 | Solidity                            | `solang`                          |
 | Solidity                            | `solc`                            |
 | Solidity                            | `solidity`                        |
+| SonarLint                           | `sonarls`                         |
 | Sphinx                              | `esbonio`                         |
 | Stylelint                           | `stylelint_lsp`                   |
 | Svelte                              | `svelte`                          |

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -117,6 +117,7 @@ M.lspconfig_to_package = {
     ["serve_d"] = "serve-d",
     ["slint_lsp"] = "slint-lsp",
     ["smithy_ls"] = "smithy-language-server",
+    ["sonarls"] = "sonarlint-language-server",
     ["solang"] = "solang",
     ["solargraph"] = "solargraph",
     ["solc"] = "solidity",


### PR DESCRIPTION
Adding a new mapping for the sonar lint server to the global maps of language servers.