### PR TITLE
fix(astro): `typescript.serverPath` -> `typescript.tsdk`

### DIFF
--- a/lua/mason-lspconfig/server_configurations/astro/init.lua
+++ b/lua/mason-lspconfig/server_configurations/astro/init.lua
@@ -4,6 +4,7 @@ local typescript = require "mason-lspconfig.typescript"
 return function(install_dir)
     return {
         on_new_config = function(new_config, workspace_dir)
+            new_config.init_options.typescript.serverPath = typescript.resolve_tsserver(install_dir, workspace_dir)
             new_config.init_options.typescript.tsdk = typescript.resolve_tsdk(install_dir, workspace_dir)
         end,
     }

--- a/lua/mason-lspconfig/server_configurations/astro/init.lua
+++ b/lua/mason-lspconfig/server_configurations/astro/init.lua
@@ -4,7 +4,7 @@ local typescript = require "mason-lspconfig.typescript"
 return function(install_dir)
     return {
         on_new_config = function(new_config, workspace_dir)
-            new_config.init_options.typescript.serverPath = typescript.resolve_tsserver(install_dir, workspace_dir)
+            new_config.init_options.typescript.tsdk = typescript.resolve_tsdk(install_dir, workspace_dir)
         end,
     }
 end


### PR DESCRIPTION
This refactor was part of `@astrojs/language-server@2.0.0`.

See https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/astro.lua

Fixes https://github.com/withastro/language-tools/issues/559