### PR TITLE
feat: add jq-lsp mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ local DEFAULT_SETTINGS = {
 | JavaScript                          | `vtsls`                           |
 | Jsonnet                             | `jsonnet_ls`                      |
 | Julia [(docs)][julials]             | `julials`                         |
+| jq.                                 | `jqls`                            |
 | Kotlin                              | `kotlin_language_server`          |
 | LaTeX                               | `ltex`                            |
 | LaTeX                               | `texlab`                          |

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ local DEFAULT_SETTINGS = {
 | JavaScript                          | `vtsls`                           |
 | Jsonnet                             | `jsonnet_ls`                      |
 | Julia [(docs)][julials]             | `julials`                         |
-| jq.                                 | `jqls`                            |
+| jq                                  | `jqls`                            |
 | Kotlin                              | `kotlin_language_server`          |
 | LaTeX                               | `ltex`                            |
 | LaTeX                               | `texlab`                          |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -71,6 +71,7 @@ intelephense                              intelephense
 java-language-server                      java_language_server
 jdtls                                     jdtls
 jedi-language-server                      jedi_language_server
+jq-lsp                                    jqls
 json-lsp                                  jsonls
 jsonnet-language-server                   jsonnet_ls
 julia-lsp                                 julials

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -68,6 +68,7 @@
 | [java_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#java_language_server) | [java-language-server](https://mason-registry.dev/registry/list#java-language-server) |
 | [jdtls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jdtls) | [jdtls](https://mason-registry.dev/registry/list#jdtls) |
 | [jedi_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jedi_language_server) | [jedi-language-server](https://mason-registry.dev/registry/list#jedi-language-server) |
+| [jqls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jqls) | [jq-lsp](https://mason-registry.dev/registry/list#jq-lsp) |
 | [jsonls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jsonls) | [json-lsp](https://mason-registry.dev/registry/list#json-lsp) |
 | [jsonnet_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jsonnet_ls) | [jsonnet-language-server](https://mason-registry.dev/registry/list#jsonnet-language-server) |
 | [julials](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#julials) | [julia-lsp](https://mason-registry.dev/registry/list#julia-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -81,6 +81,7 @@ return {
   ["javascript.glimmer"] = { "ember", "glint" },
   ["javascript.jsx"] = { "custom_elements_ls", "denols", "eslint", "tsserver", "vtsls" },
   javascriptreact = { "cssmodules_ls", "custom_elements_ls", "denols", "emmet_language_server", "emmet_ls", "eslint", "graphql", "rome", "sourcery", "stylelint_lsp", "tailwindcss", "tsserver", "unocss", "vtsls" },
+  jq = { "jqls" },
   json = { "jsonls", "rome", "spectral" },
   jsonc = { "jsonls" },
   jsonnet = { "jsonnet_ls" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -74,6 +74,7 @@ M.lspconfig_to_package = {
     ["jsonls"] = "json-lsp",
     ["jsonnet_ls"] = "jsonnet-language-server",
     ["julials"] = "julia-lsp",
+    ["jqls"] = "jq-lsp",
     ["kotlin_language_server"] = "kotlin-language-server",
     ["lelwel_ls"] = "lelwel",
     ["lemminx"] = "lemminx",


### PR DESCRIPTION
jq-lsp support was added in williamboman/mason.nvim#793
this pr adds missing mapping for it
