### PR TITLE
Delete rescript config.

### DIFF
--- a/lua/mason-lspconfig/server_configurations/rescriptls/init.lua
+++ b/lua/mason-lspconfig/server_configurations/rescriptls/init.lua
@@ -1,5 +1,0 @@
-return function()
-    return {
-        cmd = { "rescript-lsp", "--stdio" },
-    }
-end


### PR DESCRIPTION
Config override is not needed and it points to the old binary name which breaks LSP usage with lspconfig. This fixes rescript language server.