### PR TITLE
feat: add dart language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ local DEFAULT_SETTINGS = {
 | Custom Elements Language Server     | `custom_elements_ls`              |
 | Cue                                 | `dagger`                          |
 | Cypher                              | `cypher_ls`                       |
+| Dart                                | `dart_ls`                         |
 | Deno                                | `denols`                          |
 | Dhall                               | `dhall_lsp_server`                |
 | Diagnostic (general purpose server) | `diagnosticls`                    |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -37,6 +37,7 @@ cucumber-language-server                  cucumber_language_server
 custom-elements-languageserver            custom_elements_ls
 cypher-language-server                    cypher_ls
 cuelsp                                    dagger
+dart                                      dart_ls
 deno                                      denols
 dhall-lsp                                 dhall_lsp_server
 diagnostic-languageserver                 diagnosticls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -34,6 +34,7 @@
 | [custom_elements_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#custom_elements_ls) | [custom-elements-languageserver](https://mason-registry.dev/registry/list#custom-elements-languageserver) |
 | [cypher_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cypher_ls) | [cypher-language-server](https://mason-registry.dev/registry/list#cypher-language-server) |
 | [dagger](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dagger) | [cuelsp](https://mason-registry.dev/registry/list#cuelsp) |
+| [dart_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dart_ls) | [dart](https://mason-registry.dev/registry/list#dart-language-server) |
 | [denols](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#denols) | [deno](https://mason-registry.dev/registry/list#deno) |
 | [dhall_lsp_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dhall_lsp_server) | [dhall-lsp](https://mason-registry.dev/registry/list#dhall-lsp) |
 | [diagnosticls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#diagnosticls) | [diagnostic-languageserver](https://mason-registry.dev/registry/list#diagnostic-languageserver) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -37,7 +37,7 @@ return {
   cue = { "dagger" },
   cypher = { "cypher_ls" },
   d = { "serve_d" },
-  dart = { "ast_grep" },
+  dart = { "ast_grep", "dart_ls" },
   dhall = { "dhall_lsp_server" },
   ["django-html"] = { "tailwindcss" },
   dockerfile = { "dockerls" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -37,6 +37,7 @@ M.lspconfig_to_package = {
     ["custom_elements_ls"] = "custom-elements-languageserver",
     ["cypher_ls"] = "cypher-language-server",
     ["dagger"] = "cuelsp",
+    ["dart"] = "dart",
     ["denols"] = "deno",
     ["dhall_lsp_server"] = "dhall-lsp",
     ["diagnosticls"] = "diagnostic-languageserver",


### PR DESCRIPTION
## Why
Added the dart language server in the Mason's core package registry in https://github.com/mason-org/mason-registry/pull/3827.

## What
Make it available in plugin. Will resolve https://github.com/williamboman/mason-lspconfig.nvim/issues/328.