### PR TITLE
feat: add vacuum language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ local DEFAULT_SETTINGS = {
 | Odin                                | `ols`                             |
 | OneScript, 1C:Enterprise            | `bsl_ls`                          |
 | OpenAPI                             | `spectral`                        |
+| OpenAPI                             | `vacuum`                          |
 | OpenCL                              | `opencl_ls`                       |
 | OpenGL                              | `glsl_analyzer`                   |
 | OpenSCAD                            | `openscad_lsp`                    |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -177,6 +177,7 @@ typos-lsp                                 typos_lsp
 typst-lsp                                 typst_lsp
 unocss-language-server                    unocss
 v-analyzer                                v_analyzer
+vacuum                                    vacuum
 vala-language-server                      vala_ls
 vale-ls                                   vale_ls
 verible                                   verible

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -174,6 +174,7 @@
 | [typst_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#typst_lsp) | [typst-lsp](https://mason-registry.dev/registry/list#typst-lsp) |
 | [unocss](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#unocss) | [unocss-language-server](https://mason-registry.dev/registry/list#unocss-language-server) |
 | [v_analyzer](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#v_analyzer) | [v-analyzer](https://mason-registry.dev/registry/list#v-analyzer) |
+| [vacuum](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#vacuum) | [vacuum](https://mason-registry.dev/registry/list#vacuum) |
 | [vala_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#vala_ls) | [vala-language-server](https://mason-registry.dev/registry/list#vala-language-server) |
 | [vale_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#vale_ls) | [vale-ls](https://mason-registry.dev/registry/list#vale-ls) |
 | [verible](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#verible) | [verible](https://mason-registry.dev/registry/list#verible) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -97,6 +97,7 @@ return {
   javascriptreact = { "biome", "cssmodules_ls", "denols", "dprint", "emmet_language_server", "emmet_ls", "eslint", "graphql", "rome", "sourcery", "stylelint_lsp", "tailwindcss", "tsserver", "unocss", "vtsls" },
   jq = { "jqls" },
   json = { "biome", "dprint", "jsonls", "rome", "spectral" },
+  ["json.openapi"] = { "vacuum" },
   jsonc = { "biome", "dprint", "jsonls" },
   jsonnet = { "jsonnet_ls" },
   julia = { "julials" },
@@ -221,6 +222,7 @@ return {
   yaml = { "azure_pipelines_ls", "hydra_lsp", "spectral", "yamlls" },
   ["yaml.ansible"] = { "ansiblels" },
   ["yaml.docker-compose"] = { "docker_compose_language_service", "yamlls" },
+  ["yaml.openapi"] = { "vacuum" },
   yml = { "spectral" },
   zig = { "zls" },
   zir = { "zls" }

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -178,6 +178,7 @@ M.lspconfig_to_package = {
     ["typst_lsp"] = "typst-lsp",
     ["unocss"] = "unocss-language-server",
     ["v_analyzer"] = "v-analyzer",
+    ["vacuum"] = "vacuum",
     ["vala_ls"] = "vala-language-server",
     ["vale_ls"] = "vale-ls",
     ["verible"] = "verible",


### PR DESCRIPTION
Adds server mapping for [vacuum](https://github.com/daveshanley/vacuum), which recently added lsp support and is already available in the [mason-registry](https://github.com/mason-org/mason-registry/blob/main/packages/vacuum/package.yaml).

The PR in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/pull/3065) has been merged and is using the same name.