### PR TITLE
fix: remove gleam

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ local DEFAULT_SETTINGS = {
 | Flux                                | `flux_lsp`                        |
 | Foam (OpenFOAM)                     | `foam_ls`                         |
 | Fortran                             | `fortls`                          |
-| Gleam                               | `gleam`                           |
 | Glint                               | `glint`                           |
 | Go                                  | `golangci_lint_ls`                |
 | Go                                  | `gopls`                           |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -63,7 +63,6 @@ flux-lsp                                  flux_lsp
 foam-language-server                      foam_ls
 fortls                                    fortls
 fsautocomplete                            fsautocomplete
-gleam                                     gleam
 glint                                     glint
 glsl_analyzer                             glsl_analyzer
 golangci-lint-langserver                  golangci_lint_ls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -60,7 +60,6 @@
 | [foam_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#foam_ls) | [foam-language-server](https://mason-registry.dev/registry/list#foam-language-server) |
 | [fortls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fortls) | [fortls](https://mason-registry.dev/registry/list#fortls) |
 | [fsautocomplete](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fsautocomplete) | [fsautocomplete](https://mason-registry.dev/registry/list#fsautocomplete) |
-| [gleam](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#gleam) | [gleam](https://mason-registry.dev/registry/list#gleam) |
 | [glint](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#glint) | [glint](https://mason-registry.dev/registry/list#glint) |
 | [glsl_analyzer](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#glsl_analyzer) | [glsl_analyzer](https://mason-registry.dev/registry/list#glsl_analyzer) |
 | [golangci_lint_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#golangci_lint_ls) | [golangci-lint-langserver](https://mason-registry.dev/registry/list#golangci-lint-langserver) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -67,7 +67,6 @@ return {
   genie = { "vala_ls" },
   geom = { "glsl_analyzer" },
   gitcommit = { "ltex" },
-  gleam = { "gleam" },
   glsl = { "glsl_analyzer" },
   go = { "ast_grep", "golangci_lint_ls", "gopls" },
   gohtml = { "tailwindcss" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -63,7 +63,6 @@ M.lspconfig_to_package = {
     ["foam_ls"] = "foam-language-server",
     ["fortls"] = "fortls",
     ["fsautocomplete"] = "fsautocomplete",
-    ["gleam"] = "gleam",
     ["glint"] = "glint",
     ["glsl_analyzer"] = "glsl_analyzer",
     ["golangci_lint_ls"] = "golangci-lint-langserver",


### PR DESCRIPTION
Gleam should not be installed through Mason. See https://github.com/mason-org/mason-registry/pull/3872.
