### PR TITLE
feat: add fennel-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ local DEFAULT_SETTINGS = {
 | F#                                  | `fsautocomplete`                  |
 | Facility Service Definition         | `facility_language_server`        |
 | Fennel                              | `fennel_language_server`          |
+| Fennel                              | `fennel_ls`                       |
 | Flux                                | `flux_lsp`                        |
 | Foam (OpenFOAM)                     | `foam_ls`                         |
 | Fortran                             | `fortls`                          |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -60,6 +60,7 @@ esbonio                                   esbonio
 eslint-lsp                                eslint
 facility-language-server                  facility_language_server
 fennel-language-server                    fennel_language_server
+fennel-ls                                 fennel_ls
 flux-lsp                                  flux_lsp
 foam-language-server                      foam_ls
 fortls                                    fortls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -57,6 +57,7 @@
 | [eslint](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#eslint) | [eslint-lsp](https://mason-registry.dev/registry/list#eslint-lsp) |
 | [facility_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#facility_language_server) | [facility-language-server](https://mason-registry.dev/registry/list#facility-language-server) |
 | [fennel_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fennel_language_server) | [fennel-language-server](https://mason-registry.dev/registry/list#fennel-language-server) |
+| [fennel_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fennel_ls) | [fennel-ls](https://mason-registry.dev/registry/list#fennel-ls) |
 | [flux_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#flux_lsp) | [flux-lsp](https://mason-registry.dev/registry/list#flux-lsp) |
 | [foam_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#foam_ls) | [foam-language-server](https://mason-registry.dev/registry/list#foam-language-server) |
 | [fortls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fortls) | [fortls](https://mason-registry.dev/registry/list#fortls) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -57,7 +57,7 @@ return {
   erg = { "erg_language_server" },
   erlang = { "elp", "erlangls" },
   eruby = { "emmet_language_server", "emmet_ls", "stimulus_ls", "tailwindcss" },
-  fennel = { "fennel_language_server" },
+  fennel = { "fennel_language_server", "fennel_ls" },
   flux = { "flux_lsp" },
   foam = { "foam_ls" },
   fortran = { "fortls" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -60,6 +60,7 @@ M.lspconfig_to_package = {
     ["eslint"] = "eslint-lsp",
     ["facility_language_server"] = "facility-language-server",
     ["fennel_language_server"] = "fennel-language-server",
+    ["fennel_ls"] = "fennel-ls",
     ["flux_lsp"] = "flux-lsp",
     ["foam_ls"] = "foam-language-server",
     ["fortls"] = "fortls",


### PR DESCRIPTION
Fennel-ls is already in the mason [registry] and in [lspconfig].

This PR links the two together.

[registry]: https://github.com/mason-org/mason-registry/pull/4648
[lspconfig]: https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/fennel_ls.lua