### PR TITLE
Add new ruff server

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ local DEFAULT_SETTINGS = {
 | Python                              | `pylyzer`                         |
 | Python                              | `sourcery`                        |
 | Python [(docs)][pylsp]              | `pylsp`                           |
+| Python                              | `ruff`                            |
 | Python                              | `ruff_lsp`                        |
 | R                                   | `r_language_server`               |
 | Raku                                | `raku_navigator`                  |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -142,6 +142,7 @@ robotframework-lsp                        robotframework_ls
 rome                                      rome
 rubocop                                   rubocop
 ruby-lsp                                  ruby_ls
+ruff                                      ruff
 ruff-lsp                                  ruff_lsp
 rust-analyzer                             rust_analyzer
 salt-lsp                                  salt_ls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -139,6 +139,7 @@
 | [rome](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rome) | [rome](https://mason-registry.dev/registry/list#rome) |
 | [rubocop](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rubocop) | [rubocop](https://mason-registry.dev/registry/list#rubocop) |
 | [ruby_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruby_ls) | [ruby-lsp](https://mason-registry.dev/registry/list#ruby-lsp) |
+| [ruff](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff) | [ruff](https://mason-registry.dev/registry/list#ruff) |
 | [ruff_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff_lsp) | [ruff-lsp](https://mason-registry.dev/registry/list#ruff-lsp) |
 | [rust_analyzer](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer) | [rust-analyzer](https://mason-registry.dev/registry/list#rust-analyzer) |
 | [salt_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#salt_ls) | [salt-lsp](https://mason-registry.dev/registry/list#salt-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -152,7 +152,7 @@ return {
   pug = { "emmet_language_server", "emmet_ls" },
   puppet = { "puppet" },
   purescript = { "purescriptls" },
-  python = { "ast_grep", "basedpyright", "dprint", "jedi_language_server", "pylsp", "pylyzer", "pyre", "pyright", "ruff_lsp", "sourcery" },
+  python = { "ast_grep", "basedpyright", "dprint", "jedi_language_server", "pylsp", "pylyzer", "pyre", "pyright", "ruff", "ruff_lsp", "sourcery" },
   ql = { "codeqlls" },
   quarto = { "ltex" },
   r = { "r_language_server" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -143,6 +143,7 @@ M.lspconfig_to_package = {
     ["rome"] = "rome",
     ["rubocop"] = "rubocop",
     ["ruby_ls"] = "ruby-lsp",
+    ["ruff"] = "ruff",
     ["ruff_lsp"] = "ruff-lsp",
     ["rust_analyzer"] = "rust-analyzer",
     ["salt_ls"] = "salt-lsp",


### PR DESCRIPTION
`ruff` now has a built in language server, which `nvim-lspconfig` already has support for.