### PR TITLE
perf(ensure_installed): make it async

### DIFF
--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -34,7 +34,12 @@ function M.setup(config)
     end
 
     if not platform.is_headless and #settings.current.ensure_installed > 0 then
-        require "mason-lspconfig.ensure_installed"()
+        local async
+        async = vim.uv.new_async(function()
+            require "mason-lspconfig.ensure_installed"()
+            async:close()
+        end)
+        async:send()
     end
 
     local registry = require "mason-registry"


### PR DESCRIPTION
for a configuration like this:

```lua
require('mason-lspconfig').setup({
        automatic_installation = false,
        ensure_installed = {
            'clangd',
            'dockerls',
            'emmet_ls',
            'golangci_lint_ls',
            'gopls',
            'jsonls',
            'lemminx',
            'lua_ls',
            'pyright',
            'rust_analyzer',
            'tailwindcss',
            'taplo',
            'tsserver',
            'yamlls',
            'volar',
            'ast_grep',
        },
    })
```

before:
![image](https://github.com/williamboman/mason-lspconfig.nvim/assets/42114817/70855b31-d1fb-4b7b-a869-53a77bd11e98)

after:
![image](https://github.com/williamboman/mason-lspconfig.nvim/assets/42114817/b80ddf2e-b638-41b7-8013-0ab3b1f882bb)
