### PR TITLE
perf: lazy-require some modules during config

### DIFF
--- a/lua/mason-lspconfig/server_configurations/astro/init.lua
+++ b/lua/mason-lspconfig/server_configurations/astro/init.lua
@@ -1,9 +1,9 @@
-local typescript = require "mason-lspconfig.typescript"
-
 ---@param install_dir string
 return function(install_dir)
     return {
         on_new_config = function(new_config, workspace_dir)
+            local typescript = require "mason-lspconfig.typescript"
+
             new_config.init_options.typescript.serverPath = typescript.resolve_tsserver(install_dir, workspace_dir)
             new_config.init_options.typescript.tsdk = typescript.resolve_tsdk(install_dir, workspace_dir)
         end,

--- a/lua/mason-lspconfig/server_configurations/pylsp/init.lua
+++ b/lua/mason-lspconfig/server_configurations/pylsp/init.lua
@@ -1,15 +1,16 @@
 local _ = require "mason-core.functional"
 local a = require "mason-core.async"
-local notify = require "mason-lspconfig.notify"
-local pip3 = require "mason-core.managers.pip3"
-local process = require "mason-core.process"
-local spawn = require "mason-core.spawn"
 
 ---@param install_dir string
 return function(install_dir)
     vim.api.nvim_create_user_command(
         "PylspInstall",
         a.scope(function(opts)
+            local notify = require "mason-lspconfig.notify"
+            local pip3 = require "mason-core.managers.pip3"
+            local process = require "mason-core.process"
+            local spawn = require "mason-core.spawn"
+
             local plugins = opts.fargs
             local plugins_str = table.concat(plugins, ", ")
             notify(("Installing %s..."):format(plugins_str))

--- a/lua/mason-lspconfig/server_configurations/volar/init.lua
+++ b/lua/mason-lspconfig/server_configurations/volar/init.lua
@@ -1,9 +1,9 @@
-local typescript = require "mason-lspconfig.typescript"
-
 ---@param install_dir string
 return function(install_dir)
     return {
         on_new_config = function(new_config, workspace_dir)
+            local typescript = require "mason-lspconfig.typescript"
+
             local tsdk = typescript.resolve_tsdk(install_dir, workspace_dir)
             new_config.init_options.typescript.serverPath = tsdk
             new_config.init_options.typescript.tsdk = tsdk


### PR DESCRIPTION
Some modules don't need to be eagerly loaded at the config time. With this patch, when using pylsp, the following modules are no longer loaded at startup, which saves about 0.6ms on my desktop. 
* mason-core.result
* mason-core.receipt
* mason-core.process
* mason-core.spawn
* mason-core.installer.context
* mason-core.async.control
* mason-core.installer.linker
* mason-core.installer
* mason-core.providers
* mason-core.managers.pip3
