### PR TITLE
Replaced deprecated vim.tbl_islist with vim.islist

### DIFF
--- a/lua/mason-lspconfig/lspconfig_hook.lua
+++ b/lua/mason-lspconfig/lspconfig_hook.lua
@@ -39,7 +39,7 @@ local merge_in_place
 merge_in_place = _.curryN(function(t1, t2)
     for k, v in pairs(t2) do
         if type(v) == "table" then
-            if type(t1[k]) == "table" and not vim.tbl_islist(t1[k]) then
+            if type(t1[k]) == "table" and not vim.islist(t1[k]) then
                 merge_in_place(t1[k], v)
             else
                 t1[k] = v


### PR DESCRIPTION
I am using Below neovim version. 

NVIM v0.11.0-dev-15+g62eb7e79a
Build type: RelWithDebInfo
LuaJIT 2.1.1713484068


On neovim startup i have been getting the below message. 

```
vim.tbl_islist is deprecated, use vim.islist instead.
```

I was able to find only one occurence of this deprecated function and i replaced it with what is mentioned in the warning. Have'nt build or tested it as I wasn't sure how to do it(I could probably checkout that particular commit using lazy, will check in a bit) but I thought the fix was "pretty straight forward". 

 