### PR TITLE
feat: add daedalus-language-server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ local DEFAULT_SETTINGS = {
 | Cucumber | [`cucumber_language_server`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cucumber_language_server) |
 | Cue | [`dagger`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dagger) |
 | Cypher | [`cypher_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cypher_ls) |
+| Daedalus | [`daedalus_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#daedalus_ls)
 | Dart | [`ast_grep`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ast_grep) |
 | Dhall | [`dhall_lsp_server`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#dhall_lsp_server) |
 | Django | [`jinja_lsp`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#jinja_lsp) |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -42,6 +42,7 @@ cucumber-language-server                  cucumber_language_server
 custom-elements-languageserver            custom_elements_ls
 cypher-language-server                    cypher_ls
 cuelsp                                    dagger
+daedalus-language-server                  daedalus_ls
 deno                                      denols
 dhall-lsp                                 dhall_lsp_server
 diagnostic-languageserver                 diagnosticls

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -41,6 +41,7 @@ M.lspconfig_to_package = {
     ["cucumber_language_server"] = "cucumber-language-server",
     ["custom_elements_ls"] = "custom-elements-languageserver",
     ["cypher_ls"] = "cypher-language-server",
+    ["daedalus_ls"] = "daedalus-language-server",
     ["dagger"] = "cuelsp",
     ["denols"] = "deno",
     ["dhall_lsp_server"] = "dhall-lsp",


### PR DESCRIPTION
This PR adds support for https://github.com/kirides/DaedalusLanguageServer used by Gothic and Gothic II games. It depends on https://github.com/mason-org/mason-registry/pull/6776 being merged.
