### PR TITLE
fix: update required nvim version to >= 0.9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,6 @@ jobs:
             fail-fast: false
             matrix:
                 nvim_version:
-                    - v0.7.0
-                    - v0.7.2
-                    - v0.8.0
-                    - v0.8.1
-                    - v0.8.2
-                    - v0.8.3
                     - v0.9.0
                     - v0.9.1
                     - v0.9.2
@@ -27,6 +21,7 @@ jobs:
                     - v0.9.5
                     - v0.10.0
                     - v0.10.1
+                    - v0.10.2
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ table for a complete mapping.](./doc/server-mapping.md)**
 
 > `:h mason-lspconfig-requirements`
 
-- neovim `>= 0.7.0`
+- neovim `>= 0.9.0`
 - `mason.nvim`
 - `lspconfig`
 

--- a/doc/mason-lspconfig.txt
+++ b/doc/mason-lspconfig.txt
@@ -1,6 +1,6 @@
 *mason-lspconfig.nvim*
 
-Minimum version of neovim: 0.7.0
+Minimum version of neovim: 0.9.0
 
 Author: William Boman
                                        Type |gO| to see the table of contents.


### PR DESCRIPTION
nvim-lspconfig has a hard dependency on nvim >= 0.9.0. Note that mason-lspconfig itself does not, it still supports >= 0.7.0 by itself.

Co-Authored-By: Micah Halter <micah@mehalter.com>
