### PR TITLE
feat: add nextflow_ls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ local DEFAULT_SETTINGS = {
 | Metamath Zero | [`mm0_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#mm0_ls) |
 | Motoko | [`motoko_lsp`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#motoko_lsp) |
 | Move | [`move_analyzer`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#move_analyzer) |
+| Nextflow | [`nextflow_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nextflow_ls) |
 | Nginx | [`nginx_language_server`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nginx_language_server) |
 | Nickel | [`nickel_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nickel_ls) |
 | Nim | [`nim_langserver`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nim_langserver) |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -116,6 +116,7 @@ motoko-lsp                                motoko_lsp
 move-analyzer                             move_analyzer
 mutt-language-server                      mutt_ls
 neocmakelsp                               neocmake
+nextflow-language-server                  nextflow_ls
 nextls                                    nextls
 nginx-language-server                     nginx_language_server
 nickel-lang-lsp                           nickel_ls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -113,6 +113,7 @@
 | [move_analyzer](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#move_analyzer) | [move-analyzer](https://mason-registry.dev/registry/list#move-analyzer) |
 | [mutt_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#mutt_ls) | [mutt-language-server](https://mason-registry.dev/registry/list#mutt-language-server) |
 | [neocmake](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#neocmake) | [neocmakelsp](https://mason-registry.dev/registry/list#neocmakelsp) |
+| [nextflow_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nextflow_ls) | [nextflow-language-server](https://mason-registry.dev/registry/list#nextflow-language-server) |
 | [nextls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nextls) | [nextls](https://mason-registry.dev/registry/list#nextls) |
 | [nginx_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nginx_language_server) | [nginx-language-server](https://mason-registry.dev/registry/list#nginx-language-server) |
 | [nickel_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#nickel_ls) | [nickel-lang-lsp](https://mason-registry.dev/registry/list#nickel-lang-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -130,6 +130,7 @@ return {
   mysql = { "sqlls", "sqls" },
   ncl = { "nickel_ls" },
   neomuttrc = { "mutt_ls" },
+  nextflow = { "nextflow_ls" },
   nginx = { "nginx_language_server" },
   nickel = { "nickel_ls" },
   nim = { "nim_langserver", "nimls" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -115,6 +115,7 @@ M.lspconfig_to_package = {
     ["move_analyzer"] = "move-analyzer",
     ["mutt_ls"] = "mutt-language-server",
     ["neocmake"] = "neocmakelsp",
+    ["nextflow_ls"] = "nextflow-language-server",
     ["nextls"] = "nextls",
     ["nickel_ls"] = "nickel-lang-lsp",
     ["nginx_language_server"] = "nginx-language-server",

--- a/lua/mason-lspconfig/server_configurations/nextflow_ls/init.lua
+++ b/lua/mason-lspconfig/server_configurations/nextflow_ls/init.lua
@@ -1,0 +1,3 @@
+return function()
+    return { cmd = { "nextflow-language-server" } }
+end


### PR DESCRIPTION
This adds Nextflow Language Server support which was recently added to lspconfig (https://github.com/neovim/nvim-lspconfig/pull/3423)

Relies on: https://github.com/mason-org/mason-registry/pull/7480