### PR TITLE
fix: resolves #500. Add MasonLspconfigUserSettings for setup options

### DIFF
--- a/lua/mason-lspconfig/init.lua
+++ b/lua/mason-lspconfig/init.lua
@@ -17,7 +17,7 @@ local function check_and_notify_bad_setup_order()
     end
 end
 
----@param config MasonLspconfigSettings | nil
+---@param config MasonLspconfigSettings | MasonLspconfigUserSettings | nil
 function M.setup(config)
     if config then
         settings.set(config)

--- a/lua/mason-lspconfig/settings.lua
+++ b/lua/mason-lspconfig/settings.lua
@@ -22,10 +22,15 @@ local DEFAULT_SETTINGS = {
     handlers = nil,
 }
 
+---@class MasonLspconfigUserSettings
+---@field ensure_installed? string[]
+---@field automatic_installation? boolean
+---@field handlers? table<string, fun(server_name: string)>
+
 M._DEFAULT_SETTINGS = DEFAULT_SETTINGS
 M.current = M._DEFAULT_SETTINGS
 
----@param opts MasonLspconfigSettings
+---@param opts MasonLspconfigSettings | MasonLspconfigUserSettings
 function M.set(opts)
     M.current = vim.tbl_deep_extend("force", M.current, opts)
 end


### PR DESCRIPTION
Since the user `opts` passed to the `setup` call are extended with the `DEFAULT_SETTINGS` into a `MasonLspconfigSettings` object, there is no need to enforce all the fields.

This PR adds a `MasonLspconfigUserSettings` class, which is the same as `MasonLspconfigSettings` but with optional fields, resolving the LSP warnings for valid configurations (like the simple example in the README).

Regards.