### PR TITLE
feat: add postgres_lsp and postgrestools

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ local DEFAULT_SETTINGS = {
 | Sphinx | [`esbonio`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#esbonio) |
 | SQL | [`sqlls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#sqlls) |
 | SQL | [`sqls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#sqls) |
+| SQL | [`postgres_lsp`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#postgres_lsp) |
 | Standard ML | [`millet`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#millet) |
 | Starlark | [`bzl`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#bzl) |
 | Starlark | [`starlark_rust`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#starlark_rust) |

--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -135,6 +135,7 @@ pest-language-server                      pest_ls
 phpactor                                  phpactor
 pico8-ls                                  pico8_ls
 pkgbuild-language-server                  pkgbuild_language_server
+postgrestools                             postgres_lsp
 powershell-editor-services                powershell_es
 prisma-language-server                    prismals
 prosemd-lsp                               prosemd_lsp

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -132,6 +132,7 @@
 | [phpactor](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#phpactor) | [phpactor](https://mason-registry.dev/registry/list#phpactor) |
 | [pico8_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#pico8_ls) | [pico8-ls](https://mason-registry.dev/registry/list#pico8-ls) |
 | [pkgbuild_language_server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#pkgbuild_language_server) | [pkgbuild-language-server](https://mason-registry.dev/registry/list#pkgbuild-language-server) |
+| [postgres_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#postgres_lsp) | [postgrestools](https://mason-registry.dev/registry/list#postgrestools) |
 | [powershell_es](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#powershell_es) | [powershell-editor-services](https://mason-registry.dev/registry/list#powershell-editor-services) |
 | [prismals](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#prismals) | [prisma-language-server](https://mason-registry.dev/registry/list#prisma-language-server) |
 | [prosemd_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#prosemd_lsp) | [prosemd-lsp](https://mason-registry.dev/registry/list#prosemd-lsp) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -188,7 +188,7 @@ return {
   smithy = { "smithy_ls" },
   sml = { "millet" },
   solidity = { "solang", "solc", "solidity", "solidity_ls", "solidity_ls_nomicfoundation" },
-  sql = { "sqlls", "sqls", "postgres_lsp" },
+  sql = { "sqlls", "sqls" },
   ss = { "snakeskin_ls" },
   star = { "starlark_rust" },
   stylus = { "tailwindcss", "unocss" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -135,7 +135,6 @@ M.lspconfig_to_package = {
     ["phpactor"] = "phpactor",
     ["pico8_ls"] = "pico8-ls",
     ["pkgbuild_language_server"] = "pkgbuild-language-server",
-    ["postgres_lsp"] = "postgrestools",
     ["powershell_es"] = "powershell-editor-services",
     ["prismals"] = "prisma-language-server",
     ["prosemd_lsp"] = "prosemd-lsp",


### PR DESCRIPTION
adds support for `postgres_lsp` ([nvim-lspconfig pr](https://github.com/neovim/nvim-lspconfig/pull/3657)) and `postgrestools` ([mason-registry pr](https://github.com/mason-org/mason-registry/pull/9379))