### PR TITLE
fix(lsp.enable): wrap `vim.lsp.enable` with `vim.schedule`

### DIFF
--- a/lua/mason-lspconfig/features/automatic_enable.lua
+++ b/lua/mason-lspconfig/features/automatic_enable.lua
@@ -44,7 +44,10 @@ local function enable_server(mason_pkg)
         vim.lsp.config(lspconfig_name, config)
     end
 
-    vim.lsp.enable(lspconfig_name)
+    vim.schedule(function()
+        vim.lsp.enable(lspconfig_name)
+    end)
+
     enabled_servers[lspconfig_name] = true
 end
 


### PR DESCRIPTION
Since lsp-related io-loading is very slow on windows, this can cause the entire neovim to block, using `vim.schedule` prevents slow lsp loading from blocking the entire neovim.

before:
<img width="646" height="161" alt="图片" src="https://github.com/user-attachments/assets/dd5226de-458c-4991-b6b2-7944b35e364a" />

after:
<img width="687" height="142" alt="图片" src="https://github.com/user-attachments/assets/5aa9b97b-7f4f-4ac3-8b7a-b2db7b0dbfd2" />

my `mason-lspconfig`'s config written in the `nvim-lspconfig` config block, so the image are like this :)

won't affect neovim on other os.