### PR TITLE
feat(elixir): add support for dexter LSP

### DIFF
--- a/lua/mason-lspconfig/lsp/dexter.lua
+++ b/lua/mason-lspconfig/lsp/dexter.lua
@@ -1,0 +1,3 @@
+return {
+    cmd = { "dexter", "lsp" },
+}


### PR DESCRIPTION
Coupled with https://github.com/mason-org/mason-registry/pull/15428, this patch enables full-auto configuration with `dexter` as an `expert` alternative.

See the above link for screenshots.